### PR TITLE
Remove shared state from IR

### DIFF
--- a/src/backend/cranelift.rs
+++ b/src/backend/cranelift.rs
@@ -1,7 +1,7 @@
 use crate::ir::*;
 
 use cranelift_codegen::ir::types::*;
-use cranelift_codegen::ir::{AbiParam, ExternalName, Function as CLFunction, InstBuilder, Signature, InstBuilderBase, Value};
+use cranelift_codegen::ir::{AbiParam, ExternalName, Function as CLFunction, InstBuilder, Signature, InstBuilderBase, Value, Ebb};
 use cranelift_codegen::isa::CallConv;
 use cranelift_codegen::settings;
 use cranelift_codegen::verifier::verify_function;
@@ -57,57 +57,50 @@ impl CraneLiftBackend {
     }
 
     /// todo: not return string
-    pub fn convert_module(&self, module: &Module) -> String {
+    pub fn convert_module<'compiler>(&self, compiler: &'compiler Compiler<'compiler>, module: &Module) -> String {
         let mut buffer = String::new();
         for declaration in &module.declarations {
-            buffer.push_str(&self.convert_declaration(&*declaration.read().unwrap(), None));
+            buffer.push_str(&self.convert_declaration(compiler, declaration, None));
             buffer.push('\n');
         }
         buffer
     }
 
     /// todo: not return string
-    fn convert_declaration(&self, dec: &Declaration, context: Option<Either<&Box<ir::Struct>, &Box<ir::Actor>>>) -> String {
+    fn convert_declaration<'compiler>(
+        &self,
+        compiler: &'compiler Compiler<'compiler>,
+        dec: &Declaration,
+        context: Option<Either<&Box<ir::Struct>, &Box<ir::Actor>>>,
+    ) -> String {
         match dec {
             Declaration::Function(ref function) => {
-                self.convert_function(Either::Left(function), context).display(None).to_string()
+                self.convert_function(compiler, Either::Left(function), context).display(None).to_string()
             }
             Declaration::Behaviour(ref behaviour) => {
-                self.convert_function(Either::Right(behaviour), context).display(None).to_string()
+                self.convert_function(compiler, Either::Right(behaviour), context).display(None).to_string()
             }
             Declaration::Struct(ref struc) => {
                 let mut buffer = String::new();
-                let guard = struc.functions.read().unwrap();
-                for dec in guard.iter() {
-                    let guard = dec.0.lock().unwrap();
-                    if let Some(ref dec) = *guard {
-                        let dec = self.convert_declaration(&*dec.read().unwrap(), Some(Either::Left(struc)));
-                        buffer.push_str(&dec);
-                        buffer.push('\n');
-                    }
+                for dec in struc.functions.iter() {
+                    let dec = self.convert_declaration(compiler, dec, Some(Either::Left(struc)));
+                    buffer.push_str(&dec);
+                    buffer.push('\n');
                 }
                 buffer
             }
             Declaration::Actor(ref actor) => {
                 let mut buffer = String::new();
-                let guard = actor.functions.read().unwrap();
-                for dec in guard.iter() {
-                    let guard = dec.0.lock().unwrap();
-                    if let Some(ref dec) = *guard {
-                        let dec = self.convert_declaration(&*dec.read().unwrap(), Some(Either::Right(actor)));
-                        buffer.push_str(&dec);
-                        buffer.push('\n');
-                    }
+                for dec in actor.functions.iter() {
+                    let dec = self.convert_declaration(compiler, dec, Some(Either::Right(actor)));
+                    buffer.push_str(&dec);
+                    buffer.push('\n');
                 }
 
-                let guard = actor.behaviours.read().unwrap();
-                for dec in guard.iter() {
-                    let guard = dec.0.lock().unwrap();
-                    if let Some(ref dec) = *guard {
-                        let dec = self.convert_declaration(&*dec.read().unwrap(), Some(Either::Right(actor)));
-                        buffer.push_str(&dec);
-                        buffer.push('\n');
-                    }
+                for dec in actor.behaviours.iter() {
+                    let dec = self.convert_declaration(compiler, dec, Some(Either::Right(actor)));
+                    buffer.push_str(&dec);
+                    buffer.push('\n');
                 }
                 buffer
             }
@@ -115,7 +108,12 @@ impl CraneLiftBackend {
         }
     }
 
-    fn convert_function(&self, function: Either<&Box<ir::Function>, &Box<ir::Behaviour>>, context: Option<Either<&Box<ir::Struct>, &Box<ir::Actor>>>) -> CLFunction {
+    fn convert_function<'compiler>(
+        &self,
+        compiler: &'compiler Compiler<'compiler>,
+        function: Either<&Box<ir::Function>, &Box<ir::Behaviour>>,
+        context: Option<Either<&Box<ir::Struct>, &Box<ir::Actor>>>,
+    ) -> CLFunction {
         let mut sig = Signature::new(CallConv::SystemV);
         // convert return type
         if let Either::Left(function) = function {
@@ -161,58 +159,60 @@ impl CraneLiftBackend {
             Either::Left(function) => &function.blocks,
             Either::Right(behaviour) => &behaviour.blocks,
         };
-        self.convert_blocks(&mut func, blocks);
+        self.convert_blocks(compiler, &mut func, blocks);
         func
     }
 
-    fn convert_blocks(&self, mut func: &mut CLFunction, blocks: &Vec<Arc<Mutex<Block>>>) {
+    fn convert_blocks<'compiler>(&self, compiler: &'compiler Compiler<'compiler>, mut func: &mut CLFunction, blocks: &Vec<Block>) {
         let mut fn_builder_ctx = FunctionBuilderContext::new();
         let mut builder = FunctionBuilder::new(&mut func, &mut fn_builder_ctx);
 
-        let mut value_map = HashMap::new();
-        let mut block_map = HashMap::new();
+        let mut value_map: HashMap<*const Instruction, Value> = HashMap::new();
+        let mut block_map: HashMap<*const Block, Ebb> = HashMap::new();
         // create an ebb for every block
         for block in blocks {
             let ebb = builder.create_ebb();
-            let ref_block = block.as_ref() as *const Mutex<Block>;
+            let ref_block = block as *const Block;
             block_map.insert(ref_block, ebb);
         }
         for block in blocks {
-            let ref_block = block.as_ref() as *const Mutex<Block>;
+            let ref_block = block as *const Block;
             let current_ebb = block_map.get(&ref_block).unwrap();
             builder.switch_to_block(*current_ebb);
-            for instruction in &block.lock().unwrap().instructions {
-                let ref_instruction = instruction.as_ref() as *const Mutex<Instruction>;
-                let instruction = instruction.lock().unwrap();
+            for instruction in block.instructions.iter() {
+                let ref_instruction = instruction as *const Instruction;
                 match *instruction {
                     Instruction::IntegerLiteral(ref i) => {
-                        let typ = self.convert_type(instruction.get_type()).expect("int literal should be an int type");
+                        let typ = self.convert_type(instruction.get_type(compiler)).expect("int literal should be an int type");
                         let value: Value = builder.ins().iconst(typ, i.0);
                         value_map.insert(ref_instruction, value);
                     }
                     Instruction::BooleanLiteral(ref b) => {
-                        let typ = self.convert_type(instruction.get_type()).expect("int literal should be an int type");
+                        let typ = self.convert_type(instruction.get_type(compiler)).expect("int literal should be an int type");
                         let value: Value = builder.ins().bconst(typ, b.0);
                         value_map.insert(ref_instruction, value);
                     }
+                    // Instruction::GetParameter(ref param) => {
+                    //     param.name
+                    // }
                     Instruction::Jump(ref jump) => {
-                        let to_block_ref = jump.block.as_ref() as *const Mutex<Block>;
+                        let to_block_ref = jump.block as *const Block;
                         let to_block_ebb = block_map.get(&to_block_ref).expect("referred to block not in function");
                         builder.ins().jump(*to_block_ebb, &[]);
                     }
                     Instruction::Branch(ref branch) => {
-                        let condition_value = value_map.get(&(branch.condition.as_ref() as *const Mutex<Instruction>))
+                        let condition_value = value_map.get(&(branch.condition as *const Instruction))
                             .expect("missing condition value");
-                        let true_ebb = block_map.get(&(branch.true_block.as_ref() as *const Mutex<Block>))
+                        let true_ebb = block_map.get(&(branch.true_block as *const Block))
                             .expect("referred to block not in function");
-                        let false_ebb = block_map.get(&(branch.false_block.as_ref() as *const Mutex<Block>))
+                        let false_ebb = block_map.get(&(branch.false_block as *const Block))
                             .expect("referred to block not in function");
                         builder.ins().brnz(*condition_value, *true_ebb, &[]);
                         builder.ins().jump(*false_ebb, &[]);
                     }
                     Instruction::Return(ref ret) => {
                         // ref of the value we're going to return
-                        let ret_value_ref = ret.instruction.as_ref() as *const Mutex<Instruction>;
+                        let ret_value_ref = ret.instruction as *const Instruction;
                         if let Some(value) = value_map.get(&ret_value_ref) {
                             builder.ins().return_(&[value.clone()]);
                         }

--- a/src/backend/cranelift.rs
+++ b/src/backend/cranelift.rs
@@ -117,7 +117,7 @@ impl CraneLiftBackend {
         let mut sig = Signature::new(CallConv::SystemV);
         // convert return type
         if let Either::Left(function) = function {
-            if let Some(typ) = self.convert_type(function.return_type.get_type()) {
+            if let Some(typ) = self.convert_type(function.return_type.get_type(compiler)) {
                 sig.returns.push(AbiParam::new(typ));
             }
         }
@@ -129,7 +129,7 @@ impl CraneLiftBackend {
         };
 
         for (_name, arg) in args {
-            if let Some(typ) = self.convert_type(arg.get_type()) {
+            if let Some(typ) = self.convert_type(arg.get_type(compiler)) {
                 sig.params.push(AbiParam::new(typ));
             }
         }

--- a/src/ir/builtin.rs
+++ b/src/ir/builtin.rs
@@ -3,7 +3,7 @@ use crate::ir::Declaration;
 use crate::ir::types::PrimitiveType;
 use crate::ir::types::Type;
 
-pub fn find_builtin_declaration(name: String, kind: Option<ir::DeclarationKind>) -> Option<Declaration<'static>> {
+pub fn find_builtin_declaration(name: String, kind: Option<ir::DeclarationKind>) -> Option<Declaration> {
     if let Some(ir::DeclarationKind::Type) = kind {
         match name.as_str() {
             "Int8" => Some(INT8.clone()),
@@ -24,24 +24,24 @@ pub fn find_builtin_declaration(name: String, kind: Option<ir::DeclarationKind>)
     }
 }
 
-fn wrap_primitive(typ: PrimitiveType) -> Declaration<'static> {
+fn wrap_primitive(typ: PrimitiveType) -> Declaration {
     Declaration::Type(Box::new(Type::Primitive(typ)))
 }
 
 // constant declarations for builtin types
 lazy_static! {
-    pub static ref INT8: Declaration<'static> = wrap_primitive(PrimitiveType::Int(8));
-    pub static ref INT16: Declaration<'static> = wrap_primitive(PrimitiveType::Int(16));
-    pub static ref INT32: Declaration<'static> = wrap_primitive(PrimitiveType::Int(32));
-    pub static ref INT64: Declaration<'static> = wrap_primitive(PrimitiveType::Int(64));
-    pub static ref COMPTIME_INT: Declaration<'static> = wrap_primitive(PrimitiveType::Int(255));
+    pub static ref INT8: Declaration = wrap_primitive(PrimitiveType::Int(8));
+    pub static ref INT16: Declaration = wrap_primitive(PrimitiveType::Int(16));
+    pub static ref INT32: Declaration = wrap_primitive(PrimitiveType::Int(32));
+    pub static ref INT64: Declaration = wrap_primitive(PrimitiveType::Int(64));
+    pub static ref COMPTIME_INT: Declaration = wrap_primitive(PrimitiveType::Int(255));
 
-    pub static ref BOOL: Declaration<'static> = wrap_primitive(PrimitiveType::Bool);
+    pub static ref BOOL: Declaration = wrap_primitive(PrimitiveType::Bool);
 
-    pub static ref FLOAT32: Declaration<'static> = wrap_primitive(PrimitiveType::Float(32));
-    pub static ref FLOAT64: Declaration<'static> = wrap_primitive(PrimitiveType::Float(64));
-    pub static ref COMPTIME_FLOAT: Declaration<'static> = wrap_primitive(PrimitiveType::Float(255));
+    pub static ref FLOAT32: Declaration = wrap_primitive(PrimitiveType::Float(32));
+    pub static ref FLOAT64: Declaration = wrap_primitive(PrimitiveType::Float(64));
+    pub static ref COMPTIME_FLOAT: Declaration = wrap_primitive(PrimitiveType::Float(255));
 
-    pub static ref NORETURN: Declaration<'static> = wrap_primitive(PrimitiveType::NoReturn);
-    pub static ref VOID: Declaration<'static> = wrap_primitive(PrimitiveType::Void);
+    pub static ref NORETURN: Declaration = wrap_primitive(PrimitiveType::NoReturn);
+    pub static ref VOID: Declaration = wrap_primitive(PrimitiveType::Void);
 }

--- a/src/ir/builtin.rs
+++ b/src/ir/builtin.rs
@@ -1,9 +1,9 @@
 use crate::ir;
-use crate::ir::{Declaration, DeclarationContainer};
+use crate::ir::Declaration;
 use crate::ir::types::PrimitiveType;
 use crate::ir::types::Type;
 
-pub fn find_builtin_declaration(name: String, kind: Option<ir::DeclarationKind>) -> Option<ir::DeclarationContainer> {
+pub fn find_builtin_declaration(name: String, kind: Option<ir::DeclarationKind>) -> Option<Declaration<'static>> {
     if let Some(ir::DeclarationKind::Type) = kind {
         match name.as_str() {
             "Int8" => Some(INT8.clone()),
@@ -24,24 +24,24 @@ pub fn find_builtin_declaration(name: String, kind: Option<ir::DeclarationKind>)
     }
 }
 
-fn wrap_primitive(typ: PrimitiveType) -> DeclarationContainer {
-    DeclarationContainer::from(Declaration::Type(Box::new(Type::Primitive(typ))))
+fn wrap_primitive(typ: PrimitiveType) -> Declaration<'static> {
+    Declaration::Type(Box::new(Type::Primitive(typ)))
 }
 
 // constant declarations for builtin types
 lazy_static! {
-    pub static ref INT8: DeclarationContainer = wrap_primitive(PrimitiveType::Int(8));
-    pub static ref INT16: DeclarationContainer = wrap_primitive(PrimitiveType::Int(16));
-    pub static ref INT32: DeclarationContainer = wrap_primitive(PrimitiveType::Int(32));
-    pub static ref INT64: DeclarationContainer = wrap_primitive(PrimitiveType::Int(64));
-    pub static ref COMPTIME_INT: DeclarationContainer = wrap_primitive(PrimitiveType::Int(255));
+    pub static ref INT8: Declaration<'static> = wrap_primitive(PrimitiveType::Int(8));
+    pub static ref INT16: Declaration<'static> = wrap_primitive(PrimitiveType::Int(16));
+    pub static ref INT32: Declaration<'static> = wrap_primitive(PrimitiveType::Int(32));
+    pub static ref INT64: Declaration<'static> = wrap_primitive(PrimitiveType::Int(64));
+    pub static ref COMPTIME_INT: Declaration<'static> = wrap_primitive(PrimitiveType::Int(255));
 
-    pub static ref BOOL: DeclarationContainer = wrap_primitive(PrimitiveType::Bool);
+    pub static ref BOOL: Declaration<'static> = wrap_primitive(PrimitiveType::Bool);
 
-    pub static ref FLOAT32: DeclarationContainer = wrap_primitive(PrimitiveType::Float(32));
-    pub static ref FLOAT64: DeclarationContainer = wrap_primitive(PrimitiveType::Float(64));
-    pub static ref COMPTIME_FLOAT: DeclarationContainer = wrap_primitive(PrimitiveType::Float(255));
+    pub static ref FLOAT32: Declaration<'static> = wrap_primitive(PrimitiveType::Float(32));
+    pub static ref FLOAT64: Declaration<'static> = wrap_primitive(PrimitiveType::Float(64));
+    pub static ref COMPTIME_FLOAT: Declaration<'static> = wrap_primitive(PrimitiveType::Float(255));
 
-    pub static ref NORETURN: DeclarationContainer = wrap_primitive(PrimitiveType::NoReturn);
-    pub static ref VOID: DeclarationContainer = wrap_primitive(PrimitiveType::Void);
+    pub static ref NORETURN: Declaration<'static> = wrap_primitive(PrimitiveType::NoReturn);
+    pub static ref VOID: Declaration<'static> = wrap_primitive(PrimitiveType::Void);
 }

--- a/src/ir/builtin.rs
+++ b/src/ir/builtin.rs
@@ -3,24 +3,20 @@ use crate::ir::Declaration;
 use crate::ir::types::PrimitiveType;
 use crate::ir::types::Type;
 
-pub fn find_builtin_declaration(name: String, kind: Option<ir::DeclarationKind>) -> Option<Declaration> {
-    if let Some(ir::DeclarationKind::Type) = kind {
-        match name.as_str() {
-            "Int8" => Some(INT8.clone()),
-            "Int16" => Some(INT16.clone()),
-            "Int32" => Some(INT32.clone()),
-            "Int64" => Some(INT64.clone()),
-            "ComptimeInt" => Some(COMPTIME_INT.clone()),
-            "Bool" => Some(BOOL.clone()),
-            "Float32" => Some(FLOAT32.clone()),
-            "Float64" => Some(FLOAT64.clone()),
-            "ComptimeFloat" => Some(COMPTIME_FLOAT.clone()),
-            "NoReturn" => Some(NORETURN.clone()),
-            "Void" => Some(VOID.clone()),
-            _ => None
-        }
-    } else {
-        None
+pub fn find_builtin_declaration(name: String) -> Option<&'static Declaration> {
+    match name.as_str() {
+        "Int8" => Some(&*INT8),
+        "Int16" => Some(&*INT16),
+        "Int32" => Some(&*INT32),
+        "Int64" => Some(&*INT64),
+        "ComptimeInt" => Some(&*COMPTIME_INT),
+        "Bool" => Some(&*BOOL),
+        "Float32" => Some(&*FLOAT32),
+        "Float64" => Some(&*FLOAT64),
+        "ComptimeFloat" => Some(&*COMPTIME_FLOAT),
+        "NoReturn" => Some(&*NORETURN),
+        "Void" => Some(&*VOID),
+        _ => None
     }
 }
 

--- a/src/ir/convert.rs
+++ b/src/ir/convert.rs
@@ -195,9 +195,7 @@ impl ir::Compiler {
 
         let mut blocks = Vec::with_capacity(block_builder.blocks.len());
         for block in block_builder.blocks {
-            // if block.instructions.len() > 0 {
-                blocks.push(block.clone());
-            // }
+            blocks.push(block.clone());
         }
 
         let mut arguments = Vec::with_capacity(f.arguments.len());
@@ -376,29 +374,26 @@ impl ir::Compiler {
         block: &mut ir::Block,
         expression: &ast::Expression,
     ) -> ir::InstructionId {
-        let block_copy: &mut ir::Block = unsafe { &mut *(block as *mut ir::Block) };
         let ins = match expression {
             ast::Expression::BooleanLiteral(b) =>
                 ir::Instruction::BooleanLiteral(Box::new(ir::BooleanLiteral(b.as_ref().0))),
             ast::Expression::IntegerLiteral(i) =>
                 ir::Instruction::IntegerLiteral(Box::new(ir::IntegerLiteral(i.as_ref().0))),
             ast::Expression::FunctionCall(call) => {
-                let block_copy2: &mut ir::Block = unsafe { &mut *(block_copy as *mut ir::Block) };
                 let function = self.generate_ir_expression(
                     current_path,
                     completed_declarations,
                     lvt,
-                    block_copy,
+                    block,
                     &call.function,
                 );
                 let mut arguments = Vec::with_capacity(call.arguments.len());
                 for argument in call.arguments.iter() {
-                    let block_copy3: &mut ir::Block = unsafe { &mut *(block_copy2 as *mut ir::Block) };
                     let argument_ins = self.generate_ir_expression(
                         current_path,
                         completed_declarations,
                         lvt,
-                        block_copy3,
+                        block,
                         argument,
                     );
                     arguments.push(argument_ins);
@@ -488,13 +483,11 @@ impl BlockBuilder {
     }
 
     pub fn current_block(&mut self) -> &mut ir::Block {
-        let result: &mut ir::Block = self.blocks.get_mut(self.current_block).unwrap();
-        // let mut x = unsafe { &mut *(result as *mut ir::Block) };
-        result
+        self.blocks.get_mut(self.current_block).unwrap()
     }
 
     pub fn create_block(&mut self) -> &mut ir::Block {
-        // don't create a new block if the currnet block has 0 instructions
+        // don't create a new block if the current block has 0 instructions
         if self.current_block().instructions.len() > 0 {
             self.current_block = self.blocks.len();
             self.blocks.push(ir::Block::new(self.current_block));

--- a/src/ir/convert.rs
+++ b/src/ir/convert.rs
@@ -195,9 +195,9 @@ impl ir::Compiler {
 
         let mut blocks = Vec::with_capacity(block_builder.blocks.len());
         for block in block_builder.blocks {
-            if block.instructions.len() > 0 {
+            // if block.instructions.len() > 0 {
                 blocks.push(block.clone());
-            }
+            // }
         }
 
         let mut arguments = Vec::with_capacity(f.arguments.len());
@@ -494,8 +494,11 @@ impl BlockBuilder {
     }
 
     pub fn create_block(&mut self) -> &mut ir::Block {
-        self.current_block = self.blocks.len();
-        self.blocks.push(ir::Block::new(self.current_block));
+        // don't create a new block if the currnet block has 0 instructions
+        if self.current_block().instructions.len() > 0 {
+            self.current_block = self.blocks.len();
+            self.blocks.push(ir::Block::new(self.current_block));
+        }
         self.current_block()
     }
 

--- a/src/ir/debug.rs
+++ b/src/ir/debug.rs
@@ -47,7 +47,6 @@ impl Printer {
     }
 
     pub fn print_module(&mut self, compiler: &Compiler, module: &Module) {
-        println!("test");
         self.print(format!(
             "; Module: {}::{}",
             module.path.to_string(),
@@ -73,7 +72,7 @@ impl Printer {
                 self.print_function(compiler, function);
             }
             Declaration::Variable(ref variable) => {
-                self.print_variable(variable);
+                self.print_variable(compiler, variable);
             }
             _ => {}
         }
@@ -115,8 +114,8 @@ impl Printer {
         self.pop();
     }
 
-    pub fn print_variable(&mut self, variable: &Box<Variable>) {
-        self.print(format!("let {}: {}", variable.name, variable.typ.get_type().name().clone()));
+    pub fn print_variable(&mut self, compiler: &Compiler, variable: &Box<Variable>) {
+        self.print(format!("let {}: {}", variable.name, variable.typ.get_type(compiler).name().clone()));
     }
 
     pub fn print_behaviour(&mut self, compiler: &Compiler, behaviour: &Box<Behaviour>) {

--- a/src/ir/debug.rs
+++ b/src/ir/debug.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use crate::ir::*;
 use crate::util::Either;
 
@@ -48,7 +46,7 @@ impl Printer {
         }
     }
 
-    pub fn print_module<'compiler>(&mut self, compiler: &'compiler Compiler<'compiler>, module: &Module<'compiler>) {
+    pub fn print_module(&mut self, compiler: &Compiler, module: &Module) {
         println!("test");
         self.print(format!(
             "; Module: {}::{}",
@@ -60,7 +58,7 @@ impl Printer {
         }
     }
 
-    pub fn print_declaration<'compiler>(&mut self, compiler: &'compiler Compiler<'compiler>, dec: &Declaration<'compiler>) {
+    pub fn print_declaration(&mut self, compiler: &Compiler, dec: &Declaration) {
         match dec {
             Declaration::Actor(ref actor) => {
                 self.print_actor(compiler, actor);
@@ -81,7 +79,7 @@ impl Printer {
         }
     }
 
-    pub fn print_struct<'compiler>(&mut self, compiler: &'compiler Compiler<'compiler>, struc: &Box<Struct<'compiler>>) {
+    pub fn print_struct(&mut self, compiler: &Compiler, struc: &Box<Struct>) {
         self.print(format!("struct {}:", struc.name));
         self.push();
 
@@ -99,7 +97,7 @@ impl Printer {
         self.pop();
     }
 
-    pub fn print_actor<'compiler>(&mut self, compiler: &'compiler Compiler<'compiler>, actor: &Box<Actor<'compiler>>) {
+    pub fn print_actor(&mut self, compiler: &Compiler, actor: &Box<Actor>) {
         self.print(format!("actor {}:", actor.name));
         self.push();
 
@@ -121,7 +119,7 @@ impl Printer {
         self.print(format!("let {}: {}", variable.name, variable.typ.get_type().name().clone()));
     }
 
-    pub fn print_behaviour<'compiler>(&mut self, compiler: &'compiler Compiler<'compiler>, behaviour: &Box<Behaviour<'compiler>>) {
+    pub fn print_behaviour(&mut self, compiler: &Compiler, behaviour: &Box<Behaviour>) {
         let mut joined_args = "".to_string();
         for (id, (arg, dec)) in (&behaviour.arguments).iter().enumerate() {
             joined_args.push_str(&format!("%{}: {}", arg, dec.name()));
@@ -137,20 +135,14 @@ impl Printer {
         self.push();
 
         if behaviour.blocks.len() > 0 {
-            let mut instruction_ids: HashMap<*const Instruction, usize> = HashMap::new();
-            let mut block_ids: HashMap<*const Block, usize> = HashMap::new();
-            // put block ids in map
             for (id, block) in behaviour.blocks.iter().enumerate() {
-                block_ids.insert(block as *const Block, id);
-            }
-            for (id, block) in behaviour.blocks.iter().enumerate() {
-                self.print_block(compiler, &mut instruction_ids, &block_ids, id, block, Either::Right(behaviour));
+                self.print_block(compiler, id, block, Either::Right(behaviour));
             }
         }
         self.pop();
     }
 
-    pub fn print_function<'compiler>(&mut self, compiler: &'compiler Compiler<'compiler>, function: &Box<Function<'compiler>>) {
+    pub fn print_function(&mut self, compiler: &Compiler, function: &Box<Function>) {
         let mut joined_args = "".to_string();
         for (id, (arg, dec)) in (&function.arguments).iter().enumerate() {
             joined_args.push_str(&format!("%{}: {}", arg, dec.name()));
@@ -167,50 +159,38 @@ impl Printer {
         self.push();
 
         if function.blocks.len() > 0 {
-            let mut instruction_ids: HashMap<*const Instruction, usize> = HashMap::new();
-            let mut block_ids: HashMap<*const Block, usize> = HashMap::new();
-            // put block ids in map
             for (id, block) in function.blocks.iter().enumerate() {
-                block_ids.insert(block as *const Block, id);
-            }
-
-            for (id, block) in function.blocks.iter().enumerate() {
-                self.print_block(compiler, &mut instruction_ids, &block_ids, id, block, Either::Left(function));
+                self.print_block(compiler, id, block, Either::Left(function));
             }
         }
         self.pop();
     }
 
-    pub fn print_block<'compiler>(
+    pub fn print_block(
         &mut self,
-        compiler: &'compiler Compiler<'compiler>,
-        instruction_ids: &mut HashMap<*const Instruction<'compiler>, usize>,
-        block_ids: &HashMap<*const Block, usize>,
+        compiler: &Compiler,
         id: usize,
-        block: &Block<'compiler>,
+        block: &Block,
         function: Either<&Box<Function>, &Box<Behaviour>>,
     ) {
         self.print(format!("block#{}:", id));
 
         self.push();
-        for instruction in block.instructions.iter() {
-            let id = instruction_ids.len();
-            instruction_ids.insert(instruction as *const Instruction, id);
-            self.print_instruction(compiler, &instruction_ids, block_ids, id, instruction, function);
+        for (id, instruction) in block.instructions.iter().enumerate() {
+            self.print_instruction(compiler, id, instruction, block, function);
         }
         self.pop();
     }
 
-    pub fn print_instruction<'compiler>(
+    pub fn print_instruction(
         &mut self,
-        compiler: &'compiler Compiler<'compiler>,
-        instruction_ids: &HashMap<*const Instruction<'compiler>, usize>,
-        block_ids: &HashMap<*const Block, usize>,
+        compiler: &Compiler,
         id: usize,
-        instruction: &Instruction<'compiler>,
+        instruction: &Instruction,
+        block: &Block,
         function: Either<&Box<Function>, &Box<Behaviour>>,
     ) {
-        let ins_type = instruction.get_type_with_context(compiler, function).name();
+        let ins_type = instruction.get_type_with_context(compiler, block, function).name();
         match *instruction {
             Instruction::DeclarationReference(ref d) => {
                 let (path, name) = &d.name;
@@ -228,50 +208,31 @@ impl Printer {
             Instruction::BooleanLiteral(ref b) => self.print(format!("%{} : {} = {}", id, ins_type, b.as_ref().0)),
             Instruction::IntegerLiteral(ref i) => self.print(format!("%{} : {} = {}", id, ins_type, i.as_ref().0)),
             Instruction::FunctionCall(ref call) => {
-                let function = call.function as *const Instruction;
-                let function_id = if let Some(id) = instruction_ids.get(&function) {
-                    *id
-                } else {
-                    99999
-                };
-
-                let mut arg_ids = Vec::with_capacity(call.arguments.len());
-                for arg in call.arguments.iter() {
-                    let p = (*arg) as *const Instruction;
-                    let arg_id = if let Some(id) = instruction_ids.get(&p) { *id } else { 88888 };
-                    arg_ids.push(arg_id);
-                }
-                let arg_strings: Vec<String> = arg_ids.iter().map(|i| format!("%{}", *i)).collect();
+                let function_id = call.function;
+                let arg_strings: Vec<String> = call.arguments.iter().map(|i| format!("%{}", (*i).0)).collect();
                 let args_connected = arg_strings.join(", ");
 
-                self.print(format!("%{} : {} = %{}({})", id, ins_type, function_id, args_connected))
+                self.print(format!("%{} : {} = %{}({})", id, ins_type, function_id.0, args_connected))
             }
             Instruction::Return(ref ret) => {
-                let value = ret.instruction as *const Instruction;
-                let value_id = if let Some(id) = instruction_ids.get(&value) { *id } else { 77777 };
+                let value_id = ret.instruction;
 
-                self.print(format!("ret %{}", value_id))
+                self.print(format!("ret %{}", value_id.0))
             }
             Instruction::GetParameter(ref param) => {
                 self.print(format!("%{} : {} = param %{}", id, ins_type, param.name))
             }
             Instruction::Branch(ref branch) => {
-                let cond = branch.condition as *const Instruction;
-                let cond_id = if let Some(id) = instruction_ids.get(&cond) { *id } else { 66666 };
+                let cond_id = branch.condition;
 
-                let true_block = branch.true_block as *const Block;
-                let false_block = branch.false_block as *const Block;
+                let true_block_id = branch.true_block;
+                let false_block_id = branch.false_block;
 
-                let true_block_id = if let Some(id) = block_ids.get(&true_block) { *id } else { 66665 };
-                let false_block_id = if let Some(id) = block_ids.get(&false_block) { *id } else { 66664 };
-
-                self.print(format!("branch %{} block#{} block#{}", cond_id, true_block_id, false_block_id))
+                self.print(format!("branch %{} block#{} block#{}", cond_id.0, true_block_id.0, false_block_id.0))
             }
             Instruction::Jump(ref jump) => {
-                let block = jump.block as *const Block;
-
-                let block_id = if let Some(id) = block_ids.get(&block) { *id } else { 66663 };
-                self.print(format!("jump block#{}", block_id))
+                let block_id = jump.block;
+                self.print(format!("jump block#{}", block_id.0))
             }
             ref i => self.print(format!("%{} : {} = unprintable ({:?})", id, ins_type, i)),
         }

--- a/src/ir/pass/mod.rs
+++ b/src/ir/pass/mod.rs
@@ -1,38 +1,30 @@
-use std::sync::{Mutex, Arc, RwLock};
-
 use crate::ir::{Block, Declaration, Function, Module, Instruction};
 
 pub trait Pass {
-    fn pass(&self, module: &Module) {
-        for dec in module.declarations.iter() {
+    fn pass(&self, module: &mut Module) {
+        for dec in module.declarations.iter_mut() {
             self.pass_declaration(dec);
         }
     }
 
-    fn pass_declaration(&self, dec: &Arc<RwLock<Declaration>>) {
-        match *dec.write().unwrap() {
+    fn pass_declaration(&self, dec: &mut Declaration) {
+        match *dec {
             Declaration::Function(ref mut function) => {
                 self.pass_function(function);
             }
             Declaration::Behaviour(_) => {}
             Declaration::Actor(ref mut actor) => {
-                for function in actor.functions.write().unwrap().iter() {
-                    if let Some(ref func) = *function.0.lock().unwrap() {
-                        self.pass_declaration(func);
-                    }
+                for function in actor.functions.iter_mut() {
+                    self.pass_declaration(function);
                 }
 
-                for behaviour in actor.behaviours.write().unwrap().iter() {
-                    if let Some(ref behave) = *behaviour.0.lock().unwrap() {
-                        self.pass_declaration(behave);
-                    }
+                for behaviour in actor.behaviours.iter_mut() {
+                    self.pass_declaration(behaviour);
                 }
             }
             Declaration::Struct(ref mut struc) => {
-                for function in struc.functions.write().unwrap().iter() {
-                    if let Some(ref func) = *function.0.lock().unwrap() {
-                        self.pass_declaration(func);
-                    }
+                for function in struc.functions.iter_mut() {
+                    self.pass_declaration(function);
                 }
             }
             Declaration::Trait(_) => {}
@@ -51,25 +43,25 @@ impl Pass for DeadBranchRemovalPass {
         let mut dead_blocks = vec![];
         // go over every block
         'blocks: for (i, block) in function.blocks.iter().enumerate() {
-            let block_ptr = block.as_ref() as *const Mutex<Block>;
+            let block_ptr = block as *const Block;
             // compare every block to every other block
             'other_blocks: for other_block in function.blocks.iter() {
-                let other_block_ptr = other_block.as_ref() as *const Mutex<Block>;
+                let other_block_ptr = other_block as *const Block;
                 // make sure we're not comparing two blocks
                 if other_block_ptr == block_ptr { continue 'other_blocks; }
 
                 // check if block is referenced in other_block
-                for instruction in other_block.lock().unwrap().instructions.iter() {
-                    match *instruction.lock().unwrap() {
+                for instruction in other_block.instructions.iter() {
+                    match *instruction {
                         Instruction::Jump(ref j) => {
-                            let referred_block_ptr = j.block.as_ref() as *const Mutex<Block>;
+                            let referred_block_ptr = j.block as *const Block;
                             if block_ptr == referred_block_ptr {
                                 continue 'blocks;
                             }
                         }
                         Instruction::Branch(ref b) => {
-                            let referred_true_block_ptr = b.true_block.as_ref() as *const Mutex<Block>;
-                            let referred_false_block_ptr = b.false_block.as_ref() as *const Mutex<Block>;
+                            let referred_true_block_ptr = b.true_block as *const Block;
+                            let referred_false_block_ptr = b.false_block as *const Block;
                             if block_ptr == referred_true_block_ptr || block_ptr == referred_false_block_ptr {
                                 continue 'blocks;
                             }

--- a/src/ir/types.rs
+++ b/src/ir/types.rs
@@ -41,6 +41,10 @@ impl Type {
 impl Debug for Type {
     fn fmt(&self, f: &mut Formatter) -> Result {
         write!(f, "{}", self.name())?;
+        match self {
+            Type::Unresolved(unresolved) => { write!(f, "*"); }
+            _ => {}
+        }
         Ok(())
     }
 }
@@ -59,7 +63,7 @@ impl UnresolvedType {
 #[derive(Clone, Debug)]
 pub struct StructType {
     pub name: String,
-    pub fields: Vec<(String, Box<Type>)>
+    pub fields: Vec<(String, Box<Type>)>,
 }
 
 #[derive(Clone, Debug)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -328,9 +328,9 @@ actor A {
     let guard = compiler.modules.read().unwrap();
     for module in guard.iter() {
         printer.print_module(&compiler, &module);
-        // if module.name == "valid".to_string() {
-        //     let backend = CraneLiftBackend::new();
-        //     backend.convert_module(compiler.as_ref(), module);
-        // }
+        if module.name == "valid".to_string() {
+            let backend = CraneLiftBackend::new();
+            backend.convert_module(compiler.as_ref(), module);
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -287,20 +287,20 @@ actor A {
     let compiler = Arc::new(ir::Compiler::new());
 
     // simulate thread pool
-    // let handle = thread::spawn({
-    //     move || {
-    //         let compiler_copy = compiler.clone();
-    //         //            thread::sleep(std::time::Duration::from_secs(1));
-    //         let now = Instant::now();
-    //         let module = compiler_copy.generate_ir(add_program);
-    //         println!("Add Module: {:?}", now.elapsed());
-    //         compiler_copy.add_module(module);
-    //     }
-    // });
-    let now = Instant::now();
-    let module = compiler.generate_ir(add_program);
-    println!("Add Module: {:?}", now.elapsed());
-    compiler.add_module(module);
+    let handle = thread::spawn({
+        let compiler_copy = compiler.clone();
+        move || {
+            // thread::sleep(std::time::Duration::from_secs(1));
+            let now = Instant::now();
+            let module = compiler_copy.generate_ir(add_program);
+            println!("Add Module: {:?}", now.elapsed());
+            compiler_copy.add_module(module);
+        }
+    });
+    // let now = Instant::now();
+    // let module = compiler.generate_ir(add_program);
+    // println!("Add Module: {:?}", now.elapsed());
+    // compiler.add_module(module);
 
     let mut now = Instant::now();
     compiler.add_module(compiler.generate_ir(main_program));
@@ -322,7 +322,7 @@ actor A {
         }
         None => {}
     }
-    // handle.join().unwrap();
+    handle.join().unwrap();
 
     let mut printer = ir::debug::Printer::new(PrintMode::Stdout);
     let guard = compiler.modules.read().unwrap();

--- a/tests/cranelift_tests.rs
+++ b/tests/cranelift_tests.rs
@@ -12,7 +12,7 @@ pub fn check_ir(test_name: &str, code: &str, expected_ir: &str) {
     let mut parsed_program = parser::parse(Path::of("test"), test_name.to_string(), code.to_string());
     let compiler = Compiler::new();
 
-    let module = compiler.generate_ir(parsed_program.unwrap());
+    let mut module = compiler.generate_ir(parsed_program.unwrap());
     let pass = DeadBranchRemovalPass {};
     pass.pass(&mut module);
     compiler.add_module(module);
@@ -21,7 +21,7 @@ pub fn check_ir(test_name: &str, code: &str, expected_ir: &str) {
     let mut actual_ir = String::new();
     let backend = CraneLiftBackend::new();
     for module in compiler.modules.read().unwrap().iter() {
-        actual_ir = backend.convert_module(module);
+        actual_ir = backend.convert_module(&compiler, module);
     }
 
     // remove trailing new lines

--- a/tests/cranelift_tests.rs
+++ b/tests/cranelift_tests.rs
@@ -14,7 +14,7 @@ pub fn check_ir(test_name: &str, code: &str, expected_ir: &str) {
 
     let module = compiler.generate_ir(parsed_program.unwrap());
     let pass = DeadBranchRemovalPass {};
-    pass.pass(&module);
+    pass.pass(&mut module);
     compiler.add_module(module);
 
     // print the module and store it in the buffer

--- a/tests/ir_tests.rs
+++ b/tests/ir_tests.rs
@@ -11,15 +11,15 @@ pub fn check_ir(test_name: &str, code: &str, expected_ir: &str) {
     let mut parsed_program = parser::parse(Path::of("test"), test_name.to_string(), code.to_string());
     let compiler = Compiler::new();
 
-    let module = compiler.generate_ir(parsed_program.unwrap());
+    let mut module = compiler.generate_ir(parsed_program.unwrap());
     let pass = DeadBranchRemovalPass {};
-    pass.pass(&module);
+    pass.pass(&mut module);
     compiler.add_module(module);
 
     // print the module and store it in the buffer
     let mut printer = Printer::new(PrintMode::Buffer);
     for module in compiler.modules.read().unwrap().iter() {
-        printer.print_module(module);
+        printer.print_module(&compiler, module);
     }
 
     // remove trailing new lines
@@ -199,7 +199,7 @@ fun test(a: Int32) {
 }", "\
 ; Module: test::void_function
 fun @test(%a: Int32) -> Void:
-");
+  block#0:");
 }
 
 #[test]
@@ -217,8 +217,8 @@ fun @test(%a: Int32) -> Int32:
     %0 : Bool = true
     jump block#1
   block#1:
-    %2 : Int32 = param %a
-    ret %2");
+    %0 : Int32 = param %a
+    ret %0");
 }
 
 #[test]
@@ -237,14 +237,14 @@ fun @test(%a: Bool) -> Int32:
     %0 : Bool = param %a
     branch %0 block#1 block#2
   block#1:
-    %2 : ComptimeInt = 1
-    ret %2
+    %0 : ComptimeInt = 1
+    ret %0
   block#2:
-    %4 : Bool = true
+    %0 : Bool = true
     jump block#3
   block#3:
-    %6 : ComptimeInt = 0
-    ret %6");
+    %0 : ComptimeInt = 0
+    ret %0");
 }
 
 #[test]
@@ -265,17 +265,17 @@ fun @test(%a: Bool) -> Int32:
     %0 : Bool = param %a
     branch %0 block#1 block#2
   block#1:
-    %2 : ComptimeInt = 1
-    ret %2
+    %0 : ComptimeInt = 1
+    ret %0
   block#2:
-    %4 : Bool = false
-    jump block#3
-  block#3:
-    %6 : Bool = true
+    %0 : Bool = false
     jump block#4
+  block#3:
+    %0 : Bool = true
+    jump block#5
   block#4:
-    %8 : ComptimeInt = 3
-    ret %8");
+    %0 : ComptimeInt = 3
+    ret %0");
 }
 
 #[test]
@@ -302,38 +302,38 @@ fun @foo(%a: Bool, %b: Bool, %c: Bool, %d: Bool, %e: Bool) -> Int32:
     %0 : Bool = param %a
     branch %0 block#1 block#2
   block#1:
-    %2 : ComptimeInt = 1
-    ret %2
+    %0 : ComptimeInt = 1
+    ret %0
   block#2:
-    %4 : Bool = param %b
-    branch %4 block#3 block#4
+    %0 : Bool = param %b
+    branch %0 block#3 block#4
   block#3:
-    %6 : ComptimeInt = 2
-    ret %6
+    %0 : ComptimeInt = 2
+    ret %0
   block#4:
-    %8 : Bool = param %c
-    branch %8 block#5 block#6
+    %0 : Bool = param %c
+    branch %0 block#5 block#6
   block#5:
-    %10 : ComptimeInt = 3
-    ret %10
+    %0 : ComptimeInt = 3
+    ret %0
   block#6:
-    %12 : Bool = param %d
-    branch %12 block#7 block#8
+    %0 : Bool = param %d
+    branch %0 block#7 block#8
   block#7:
-    %14 : ComptimeInt = 4
-    ret %14
+    %0 : ComptimeInt = 4
+    ret %0
   block#8:
-    %16 : Bool = param %e
-    branch %16 block#9 block#10
+    %0 : Bool = param %e
+    branch %0 block#9 block#10
   block#9:
-    %18 : ComptimeInt = 5
-    ret %18
+    %0 : ComptimeInt = 5
+    ret %0
   block#10:
-    %20 : Bool = true
+    %0 : Bool = true
     jump block#11
   block#11:
-    %22 : ComptimeInt = 6
-    ret %22");
+    %0 : ComptimeInt = 6
+    ret %0");
 }
 
 #[test]
@@ -356,21 +356,21 @@ fun @foo(%a: Bool, %b: Bool) -> Int32:
     %0 : Bool = param %a
     branch %0 block#1 block#5
   block#1:
-    %2 : Bool = param %b
-    branch %2 block#2 block#3
+    %0 : Bool = param %b
+    branch %0 block#2 block#3
   block#2:
-    %4 : ComptimeInt = 1
-    ret %4
+    %0 : ComptimeInt = 1
+    ret %0
   block#3:
-    %6 : Bool = true
+    %0 : Bool = true
     jump block#4
   block#4:
-    %8 : ComptimeInt = 2
-    ret %8
+    %0 : ComptimeInt = 2
+    ret %0
   block#5:
-    %10 : Bool = true
+    %0 : Bool = true
     jump block#6
   block#6:
-    %12 : ComptimeInt = 3
-    ret %12");
+    %0 : ComptimeInt = 3
+    ret %0");
 }


### PR DESCRIPTION
This PR removes all shared state between structs in the IR by removing Arcs and Mutexes and replacing them with constant IDs for declarations, blocks, & instructions. This method is much nicer to use in Rust since Rust demands many things when using pointers.

The tests are working but there are still a few spots using `unsafe` to copy mutable references which can be improved. I was just writing crap code until it compiled.

Closes #1 because I have decided using Zig wouldn't be the best decision. The language is too new and even starting out with a basic AST showed issues in the compiler. It's a lovely language but it's not ready yet.